### PR TITLE
fix issue #21

### DIFF
--- a/b-cdn-drm-vod-dl.py
+++ b/b-cdn-drm-vod-dl.py
@@ -119,7 +119,7 @@ class BunnyVideoDRM:
                 f'https://iframe.mediadelivery.net/{self.guid}/playlist.drm',
                 params=params,
                 headers=self.headers['playlist'])
-            resolutions = re.findall(r'RESOLUTION=(.*)', response.text)[::-1]
+            resolutions = re.findall(r'\s*(.*?)\s*/video\.drm', response.text)[::-1]
             if not resolutions:
                 sys.exit(2)
             else:


### PR DESCRIPTION
bunny introduced new way of generating playlist/segment urls.

previously it was:
1920x1080/video.drm?contextId=be70e57a-9900-452d-92a6-5dce15913163
now it is:
1080p/video.drm?contextId=56a415d2-6fa7-4f34-8e42-ce97583dd01b

this fix handles both of scenarios